### PR TITLE
Refactor slightly to avoid double-entry in the case of an unhandled error in the callback function

### DIFF
--- a/geohub.js
+++ b/geohub.js
@@ -7,14 +7,26 @@ module.exports = {
     var url = 'https://raw.github.com/'+ user + '/' + repo + '/master/' + path + '.geojson';
     request(url, function( error, response, body ){
       if (!error && response.statusCode == 200) {
-        var json = JSON.parse( body );
+      	var geojson = null;
         try {
+          var json = JSON.parse( body );
           if (json.type && json.type == 'FeatureCollection'){
-            callback( null, json );
+          	geojson = json;
           }
         } catch (e){
           callback('Error: could not parse file contents' + e, null);
+          return;
         }
+        
+        if ( geojson ) {
+        	callback( null, geojson );
+        } else {
+        	callback('Error: could not find any geojson at ' + url, null);
+        }
+      } else if (response.statusCode == 404) {
+      	callback("File not found at: " + url, null);
+      } else {
+      	callback("Error '" + error + "' occurred reading from " + url, null);
       }
     });
   },
@@ -46,9 +58,12 @@ module.exports = {
         } else {
           callback('Error: could not find any geojson in gist #' + id, null);
         }
+      } else if (response.statusCode == 404) {
+      	callback("Gist not found at: " + url, null);
+      } else {
+      	callback("Error '" + error + "' occurred reading from " + url, null);
       }
     });
     
   }
-
 };


### PR DESCRIPTION
An error in the callback function is caught by the catch() statement in repo() (Line 13) and then the same callback is called once more from the catch() statement (Line 16).

```
var json = JSON.parse( body );
try {
  if (json.type && json.type == 'FeatureCollection'){
    callback( null, json );
  }
} catch (e) {
  callback('Error: could not parse file contents' + e, null);
}
```

This leads to very confusing output from the callback and also hides potentially useful crash information when the callback is initially called and errors out. It's also different to the gist function.

[Edited - this wasn't re-entrancy :)]
