### PR TITLE
introspect repo contents for correct extension instead of hardcoding '.geojson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+* introduced support for fetching GeoJSON from files with an extension other than `.geojson` (ex: `.json`)
+
 ## [1.0.2] - 2015-10-01
 ### Fixed
 * move `debug` a from devDependences to dependencies (oops)
@@ -41,5 +46,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.3.2 - 2014-08-11
 * legacy release
 
+[Unreleased]: https://github.com/koopjs/geohub/compare/v1.0.2...HEAD
 [1.0.2]: https://github.com/koopjs/geohub/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/koopjs/geohub/compare/v1.0.0...v1.0.1

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -20,7 +20,6 @@ function repo (options, callback) {
 
   if (path) {
     var contentsUrl = '/repos/' + user + '/' + repo + '/contents/'
-
     return request({
       url: contentsUrl,
       qs: {
@@ -34,8 +33,16 @@ function repo (options, callback) {
       }
 
       var isDir = false
+      // assume the extension of the requested file is '.geojson', unless proven otherwise
+      var extension = '.geojson'
 
       data.forEach(function (f) {
+        // find out the extension of the file requested by the user
+        var filenameArray = f.name.split('.')
+        if (path === filenameArray[0]) {
+          extension = '.' + filenameArray[1]
+        }
+
         if (f.name === path && f.type === 'dir') isDir = true
       })
 
@@ -71,8 +78,8 @@ function repo (options, callback) {
       }
 
       var urls = [
-        'https://api.github.com/repos/' + user + '/' + repo + '/contents/' + path + '.geojson',
-        'https://raw.github.com/' + user + '/' + repo + '/' + branch + '/' + path + '.geojson'
+        'https://api.github.com/repos/' + user + '/' + repo + '/contents/' + path + extension,
+        'https://raw.github.com/' + user + '/' + repo + '/' + branch + '/' + path + extension
       ]
 
       async.map(urls, function (url, cb) {


### PR DESCRIPTION
resolves koopjs/koop-github#5

this code feels incredibly ugly/brittle to me, but it enables the github provider to return results for both `.json` and `.geojson` resources.

review would be *greatly* appreciated, as i'm sure there's substantial room for improvement.