### PR TITLE
Patch to fix error handling in request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* return callback in request handling when JSON parsing fails.
+
 ## [1.0.3] - 2015-10-22
 
 ### Added

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
-const request = require('request')
-const debug = require('debug')('geohub:request')
-const pkg = require('../package.json')
-const apiBase = 'https://api.github.com'
+var request = require('request')
+var debug = require('debug')('geohub:request')
+var pkg = require('../package.json')
+var apiBase = 'https://api.github.com'
 
 /**
  * handles requests by geohub to the github API
@@ -27,11 +27,13 @@ function geohubRequest (options, callback) {
 
   request(options, function (err, res, body) {
     if (err) return callback(err)
-    let json
+
     try {
-      json = JSON.parse(body)
+      var json = JSON.parse(body)
     } catch (e) {
-      return callback(new Error(`Failed to parse JSON from ${options.url} (status code: ${res.statusCode}, body: ${body})`))
+      var msg = 'Failed to parse JSON from ' + options.url
+      msg += ' (status code: ' + res.statusCode + ', body: ' + body + ')'
+      return callback(new Error(msg))
     }
 
     if (json.message) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
-var request = require('request')
-var debug = require('debug')('geohub:request')
-var pkg = require('../package.json')
-var apiBase = 'https://api.github.com'
+const request = require('request')
+const debug = require('debug')('geohub:request')
+const pkg = require('../package.json')
+const apiBase = 'https://api.github.com'
 
 /**
  * handles requests by geohub to the github API
@@ -27,13 +27,11 @@ function geohubRequest (options, callback) {
 
   request(options, function (err, res, body) {
     if (err) return callback(err)
-
+    let json
     try {
-      var json = JSON.parse(body)
+      json = JSON.parse(body)
     } catch (e) {
-      var msg = 'Failed to parse JSON from ' + options.url
-      msg += ' (status code: ' + res.statusCode + ', body: ' + body + ')'
-      callback(new Error(msg))
+      return callback(new Error(`Failed to parse JSON from ${options.url} (status code: ${res.statusCode}, body: ${body})`))
     }
 
     if (json.message) {


### PR DESCRIPTION
Found a bug.  When JSON parsing fails, an error is instantiated and passed to the callback.  However, the callback isn't followed by a return statement, so function execution continues where that parsed JSON is required, but of course it is undefined.

This PR patches the issue.